### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,21 @@ promise proxy middleware for koa
 npm install kor-proxy
 ```
 
+### Aim
+This middleware is supported do two things:
+1. Set Proxy Server Four options: (host [, protocol] [, auth] [, port])
+2. Rewrite the proxy request Header
+Match request will respond automatical internally use `Stream.pipe`.
+
 ### Hello Kor-proxy
 ```js
 const Koa = require('neat-kor'); // router wrap for Koa
 const proxy = require('kor-proxy');
 const app = new Koa();
 
-const opts = {}; // the same as http(s).request 's options parameter
 const ext = {
-  dealHeader() {
+  timeout: 1000,
+  headerRewrite() {
     // selected, deal req.headers before proxy;
   },
   dealTimeout() {
@@ -22,18 +28,26 @@ const ext = {
   },
 }
 
-app.get('/proxy', proxy('https://auth:pwd@test.url.com:8080', opts, ext));
+app.get('/proxy1', proxy('https://auth:pwd@test.url.com:8080', ext));
+
+// the same as http(s).request 's options parameter
+const options = {
+  protocol: 'https', // defalut is http:
+  auth: 'auth:pwd', // default is null
+  host: 'test.url.com', // must pass!
+  port: '8088', // defalut is 80(443)
+};
+app.get('/proxy2', proxy(options, ext));
 ```
 
 ## API
 
-### proxy([target] [, opts] [, ext])
-
-- `target` (str) - The absolute url path for proxy target, Eg: `http(s)://auth:pwd@www.proxy.com:8080`.It's used for getting `protocol, auth, host, port` properties, can also be defined explicitly in `options`.
+### proxy(options [, ext])
+- `options`(str | obj) - The absolute url path for proxy target, Eg: `http(s)://auth:pwd@www.proxy.com:8080`.It's used for getting `protocol, auth, host, port` properties, can also be defined explicitly in `options`.
 - `opts` (obj) - additional options will pass to http(s).request's `options` parameters. Eg: `agent, headers..`
 - `ext` (obj) - extension object.
-- `ext.timeout` (num) - timeout(ms) between proxy request send and recieve response.
-- `ext.dealHeader` (fn) - : deal headers before proxy.
+- `ext.timeout` (num) - timeout(ms) between proxy request send and recieve response, defalut is 15s.
+- `ext.headerRewrite` (fn) - : deal headers before proxy, recieve one param, the raw `message.headers`.
 - `ext.dealTimeout` (fn) - : deal timeout error when proxy, if none will `ctx.throw('proxy-timeout')`.
 
 ### Error Handle

--- a/index.js
+++ b/index.js
@@ -37,20 +37,16 @@ const parseTarget = (target) => {
 }
 
 // path default use ctx.req.url
-module.exports = function proxy(target = {}, options = {}, ext = {}) {
-  if (typeof target === 'string') {
-    Object.assign(options, parseTarget(target));
-  } else {
-    ext = options; // options -> ext
-    options = target; // target -> options
+module.exports = function proxy(options = {}, ext = {}) {
+  if (typeof options === 'string') {
+    options = parseTarget(options);
   }
-  target = null; // target is use for get protocol, auth, host, port
   const {
     timeout,
-    dealHeader,
+    headerRewrite,
     dealTimeout,
   } = ext;
-  const proHeader = processHeader(dealHeader, options.headers);
+  const proHeader = processHeader(headerRewrite, options.headers);
   if (!options.host) throw new Error('Target Must Have a host!');
   if (!options.agent) options.agent = newAgent(options.protocol);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kor-proxy",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "promise proxy middleware for koa",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
update to version 1.0.4,
options only support string or obj,
reference of http.request.